### PR TITLE
Fix ::close not being defined on Unix

### DIFF
--- a/Debug/Log.cpp
+++ b/Debug/Log.cpp
@@ -25,6 +25,7 @@
 #else
 
 #include <fcntl.h>
+#include <unistd.h>
 
 #endif
 

--- a/Network/Socket.cpp
+++ b/Network/Socket.cpp
@@ -44,6 +44,7 @@ typedef int				socklen_t;
 #include <netdb.h>
 #include <errno.h>
 #include <signal.h>
+#include <unistd.h>
 
 typedef int				SOCKET;
 

--- a/Network/UDPServer.cpp
+++ b/Network/UDPServer.cpp
@@ -29,6 +29,7 @@ typedef int				socklen_t;
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <errno.h>
+#include <unistd.h>
 
 typedef int				SOCKET;
 


### PR DESCRIPTION
::close is defined in unistd.h on Unix platforms
