### PR TITLE
Resourcer: fix template opening

### DIFF
--- a/Tools/ResourcerDoc/Port.cpp
+++ b/Tools/ResourcerDoc/Port.cpp
@@ -615,6 +615,10 @@ CDocument* PortTemplate::CreateNewDocument()
 	return( NULL );
 }
 
+CDocument* PortTemplate::OpenDocumentFile(LPCSTR lpszPathName, BOOL bAddToMRU, BOOL bMakeVisible) {
+	return OpenDocumentFile(lpszPathName, bMakeVisible);
+}
+
 CDocument* PortTemplate::OpenDocumentFile( LPCTSTR lpszPathName, BOOL bMakeVisible /*= TRUE*/ )
 {
 	Port::Ref pDocument;

--- a/Tools/ResourcerDoc/Port.h
+++ b/Tools/ResourcerDoc/Port.h
@@ -174,6 +174,7 @@ public:
 	// CDocTemplate interface
 	virtual CDocument* CreateNewDocument();
 	virtual CDocument* OpenDocumentFile( LPCTSTR lpszPathName, BOOL bMakeVisible = TRUE );
+	virtual CDocument* OpenDocumentFile( LPCTSTR lpszPathName, BOOL bAddToMRU, BOOL bMakeVisible);
 	virtual CFrameWnd* CreateNewFrame( CDocument* pDoc, CFrameWnd* pOther );
 };
 


### PR DESCRIPTION
It seems that OpenDocumentFile has changed in MFC140 compared to what we
had using MFC80